### PR TITLE
Udpate amazon provider

### DIFF
--- a/dags/salesforce_to_snowflake_native.py
+++ b/dags/salesforce_to_snowflake_native.py
@@ -9,8 +9,8 @@ from datetime import datetime
 from airflow.models import DAG
 from airflow.models.baseoperator import chain
 from airflow.operators.dummy import DummyOperator
-from airflow.providers.amazon.aws.operators.s3_copy_object import S3CopyObjectOperator
-from airflow.providers.amazon.aws.operators.s3_delete_objects import S3DeleteObjectsOperator
+from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator
+from airflow.providers.amazon.aws.operators.s3 import S3DeleteObjectsOperator
 from airflow.providers.amazon.aws.transfers.salesforce_to_s3 import SalesforceToS3Operator
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 from airflow.providers.snowflake.transfers.s3_to_snowflake import S3ToSnowflakeOperator

--- a/dags/salesforce_to_snowflake_native_hightouch.py
+++ b/dags/salesforce_to_snowflake_native_hightouch.py
@@ -12,8 +12,8 @@ from airflow_provider_hightouch.operators.hightouch import HightouchTriggerSyncO
 from airflow.models import DAG
 from airflow.models.baseoperator import chain
 from airflow.operators.dummy import DummyOperator
-from airflow.providers.amazon.aws.operators.s3_copy_object import S3CopyObjectOperator
-from airflow.providers.amazon.aws.operators.s3_delete_objects import S3DeleteObjectsOperator
+from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator
+from airflow.providers.amazon.aws.operators.s3 import S3DeleteObjectsOperator
 from airflow.providers.amazon.aws.transfers.salesforce_to_s3 import SalesforceToS3Operator
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 from airflow.providers.snowflake.transfers.s3_to_snowflake import S3ToSnowflakeOperator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow-providers-amazon==2.1.0
+apache-airflow-providers-amazon==6.0.0
 apache-airflow-providers-http==2.0.1
 apache-airflow-providers-salesforce==3.1.0
 apache-airflow-providers-snowflake==2.0.0


### PR DESCRIPTION
Amazon provider version was not compatible with new runtime version so needed to be updated, and the module imports to match.